### PR TITLE
Adds patch for to_hash method

### DIFF
--- a/lib/ldap/conn.rb
+++ b/lib/ldap/conn.rb
@@ -1,5 +1,17 @@
 module LDAP  
   module ConnImplementation
+
+    if RUBY_PLATFORM =~ /^java.*/i
+      class LDAP::Entry
+        def to_hash
+           h = {}
+           get_attributes.each { |a| h[a.to_sym] = self[a] }
+           h[:dn] = [dn]
+           h
+        end
+      end
+    end
+
     def controls(*args)
       raise "NOT IMPLEMENTED"
     end


### PR DESCRIPTION
* As detailed in many posts about issues with jruby-ldap and puppet server:
* https://groups.google.com/forum/#!topic/puppet-users/DKu4e7dzhvE